### PR TITLE
Fixed bug with video timer not progressing after moving the rangeslider

### DIFF
--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -559,9 +559,7 @@
         else if (this.rs.right.pressed)
             this.setPosition(1, left);
 
-        //Fix a problem with the presition in the display time
-        var ctd = this.player_.controlBar.currentTimeDisplay;
-        ctd.contentEl_.innerHTML = '<span class="vjs-control-text">' + ctd.localize('Current Time') + '</span>' + vjs.formatTime(this.rs._seconds(left), this.player_.duration());
+        this.player_.currentTime(this.rs._seconds(left));
 
         // Trigger slider change
         if (this.rs.left.pressed || this.rs.right.pressed) {


### PR DESCRIPTION
When the rangeslider is moved, the video current time stops progressing. For example, in the given demo at http://danielcebrian.com/rangeslider/demo.html, if you move the rangeslider, the current time of the video does not change even though the video is still playing. This pull request fixes that bug.